### PR TITLE
Add CI test coverage of multiple Poetry versions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,7 +1,7 @@
 name: Lint
 
 env:
-  POETRY_VERSION: "1.2.0"
+  POETRY_VERSION: "1.4.1"
 
 on:
   pull_request:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Set up Poetry
         run: |
-          pip install poetry${{ matrix.poetry-version }}
+          pip install "poetry${{ matrix.poetry-version }}"
 
       - name: Install packages
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,7 @@ env:
   # https://github.com/pytest-dev/pytest/issues/7443
   # https://github.com/actions/runner/issues/241
   PY_COLORS: 1
+  POETRY_BOOTSTRAP_VERSION: "1.4.1"
 
 on:
   pull_request:
@@ -45,9 +46,9 @@ jobs:
           - "3.11"
           - "3.12-dev"
         poetry-version:
-          - ">=1.2,<1.3"
-          - ">=1.3,<1.4"
-          - ">=1.4"
+          - "1.2"
+          - "1.3"
+          - "1.4"
 
         include:
           # Run 3.12 tests with relaxed constraints
@@ -72,16 +73,17 @@ jobs:
           # TODO: This appears to require poetry to be installed before usage
           # cache: "poetry"
 
-      - name: Set up Poetry
+      - name: Install Poetry for boostrapping
         run: |
-          pip install "poetry${{ matrix.poetry-version }}"
-
-          # Ensure the lock file is valid for this version of poetry
-          poetry lock --no-update
+          pip install "poetry==${{ env.POETRY_BOOTSTRAP_VERSION }}"
 
       - name: Install packages
         run: |
           poetry install
+
+      - name: Install Poetry ${{ matrix.poetry-version }} for testing
+        run: |
+          poetry add "poetry@~${{ matrix.poetry-version }}"
 
       - name: Relax constraints
         if: ${{ matrix.relax }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,6 @@ env:
   # https://github.com/pytest-dev/pytest/issues/7443
   # https://github.com/actions/runner/issues/241
   PY_COLORS: 1
-  POETRY_VERSION: "1.2.0"
 
 on:
   pull_request:
@@ -45,6 +44,10 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12-dev"
+        poetry-version:
+          - ">=1.2,<1.3"
+          - ">=1.3,<1.4"
+          - ">=1.4"
 
         include:
           # Run 3.12 tests with relaxed constraints
@@ -71,7 +74,7 @@ jobs:
 
       - name: Set up Poetry
         run: |
-          pip install poetry==${{ env.POETRY_VERSION }}
+          pip install poetry${{ matrix.poetry-version }}
 
       - name: Install packages
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,6 @@ env:
   # https://github.com/pytest-dev/pytest/issues/7443
   # https://github.com/actions/runner/issues/241
   PY_COLORS: 1
-  POETRY_BOOTSTRAP_VERSION: "1.4.1"
 
 on:
   pull_request:
@@ -73,21 +72,18 @@ jobs:
           # TODO: This appears to require poetry to be installed before usage
           # cache: "poetry"
 
-      - name: Install Poetry for boostrapping
+      - name: Install Poetry ${{ matrix.poetry-version }}
         run: |
-          pip install "poetry==${{ env.POETRY_BOOTSTRAP_VERSION }}"
+          pip install "poetry~=${{ matrix.poetry-version }}"
 
       - name: Install packages
         run: |
           poetry install
 
-      - name: Install Poetry ${{ matrix.poetry-version }} for testing
-        run: |
-          poetry add "poetry@~${{ matrix.poetry-version }}"
-
       - name: Relax constraints
         if: ${{ matrix.relax }}
         run: |
+          # Install the plugin
           poetry self add $(pwd)
           poetry relax --update
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   python-tests:
-    name: Python tests
+    name: Python ${{ matrix.python-version }}, Poetry ${{ matrix.poetry-version}}
 
     strategy:
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,6 +76,9 @@ jobs:
         run: |
           pip install "poetry${{ matrix.poetry-version }}"
 
+          # Ensure the lock file is valid for this version of poetry
+          poetry lock --no-update
+
       - name: Install packages
         run: |
           poetry install

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -57,7 +57,7 @@ def seeded_relax_command(
 
     # Assert that the update above was successful
     assert check_paths_relative(
-        relax_command.command.poetry.file, seeded_poetry_project_path
+        relax_command.command.poetry.file.path, seeded_poetry_project_path
     ), f"""
         The poetry application's config file should be relative to the test project path:
             {seeded_poetry_project_path}


### PR DESCRIPTION
Adds test coverage for multiple Poetry version (1.2.x, 1.3.x, and 1.4.x) since we were previously only using 1.2.0 to bootstrap then running tests with the latest version.