### PR TITLE
Fix Poetry version testing in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,10 +76,11 @@ jobs:
         run: |
           pip install "poetry~=${{ matrix.poetry-version }}"
 
+          # Ensure that Poetry is not upgraded past the version we are testing
+          poetry add "poetry@~${{ matrix.poetry-version }}" --lock
+
       - name: Install packages
         run: |
-          # Ensure that Poetry is not upgraded past the version we are testing
-          poetry add "poetry@~${{ matrix.poetry-version }}"
           poetry install
 
       - name: Relax constraints

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Install Poetry ${{ matrix.poetry-version }}
         run: |
-          pip install "poetry~=${{ matrix.poetry-version }}"
+          pip install "poetry~=${{ matrix.poetry-version }}.0"
 
           # Ensure that Poetry is not upgraded past the version we are testing
           poetry add "poetry@~${{ matrix.poetry-version }}" --lock

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -78,6 +78,8 @@ jobs:
 
       - name: Install packages
         run: |
+          # Ensure that Poetry is not upgraded past the version we are testing
+          poetry add "poetry@~${{ matrix.poetry-version }}"
           poetry install
 
       - name: Relax constraints


### PR DESCRIPTION
Follow-up to #12 addressing a bug where 

1. pip installs the latest version instead of the matrix version of Poetry
2. Poetry is upgraded in the project after installation of our preferred version


e.g. https://github.com/madkinsz/poetry-relax/actions/runs/4508024942/jobs/7936359708