### PR TITLE
Add minimal dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
It'd be nice to keep the lockfile updated automatically.

Note to future self, https://github.com/dependabot/dependabot-core/issues/1556 looks annoying