### PR TITLE
Add support for multiple groups and relax all groups by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ Preview the changes `poetry relax` would make without modifying the project:
 $ poetry relax --dry-run
 ```
 
+Relax constraints for specific dependency groups:
+
+```bash
+$ poetry relax --only foo --only bar
+```
+
 ## Examples
 
 The behavior of Poetry is quite reasonable for local development! `poetry relax` is most useful when used in CI/CD pipelines.

--- a/src/poetry_relax/_core.py
+++ b/src/poetry_relax/_core.py
@@ -38,6 +38,7 @@ else:
 
 if POETRY_VERSION < packaging.version.Version("1.3.0"):
     # Poetry 1.2.x defined a different name for Cleo 1.x
+    # isort: off
     from poetry.console.exceptions import (  # type: ignore
         PoetrySimpleConsoleException as PoetryConsoleError,
     )

--- a/src/poetry_relax/_core.py
+++ b/src/poetry_relax/_core.py
@@ -38,11 +38,11 @@ else:
 
 if POETRY_VERSION < packaging.version.Version("1.3.0"):
     # Poetry 1.2.x defined a different name for Cleo 1.x
-    from poetry.console.exceptions import (
+    from poetry.console.exceptions import (  # type: ignore
         PoetrySimpleConsoleException as PoetryConsoleError,
     )
 else:
-    from poetry.console.exceptions import PoetryConsoleError
+    from poetry.console.exceptions import PoetryConsoleError  # noqa: F401
 
 
 # Regular expressions derived from `poetry.core.semver.helpers.parse_constraint`

--- a/src/poetry_relax/_core.py
+++ b/src/poetry_relax/_core.py
@@ -9,6 +9,14 @@ from copy import copy
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Optional
 
 import packaging.version
+from poetry.core.packages.dependency_group import MAIN_GROUP
+
+if TYPE_CHECKING:
+    # See https://github.com/python-poetry/cleo/pull/254 for ignore
+    from cleo.io.io import IO  # type: ignore
+    from poetry.core.packages.dependency import Dependency
+    from poetry.installation.installer import Installer
+    from poetry.poetry import Poetry
 
 if sys.version_info < (3, 8):  # Python 3.7 support
     import pkg_resources
@@ -27,14 +35,15 @@ if POETRY_VERSION < packaging.version.Version("1.3.0"):
 else:
     from poetry.core.constraints.version import VersionRange
 
-from poetry.core.packages.dependency_group import MAIN_GROUP
 
-if TYPE_CHECKING:
-    # See https://github.com/python-poetry/cleo/pull/254 for ignore
-    from cleo.io.io import IO  # type: ignore
-    from poetry.core.packages.dependency import Dependency
-    from poetry.installation.installer import Installer
-    from poetry.poetry import Poetry
+if POETRY_VERSION < packaging.version.Version("1.3.0"):
+    # Poetry 1.2.x defined a different name for Cleo 1.x
+    from poetry.console.exceptions import (
+        PoetrySimpleConsoleException as PoetryConsoleError,
+    )
+else:
+    from poetry.console.exceptions import PoetryConsoleError
+
 
 # Regular expressions derived from `poetry.core.semver.helpers.parse_constraint`
 # These are used to parse complex constraint strings into single constraints

--- a/src/poetry_relax/command.py
+++ b/src/poetry_relax/command.py
@@ -17,6 +17,14 @@ from poetry_relax._core import (
     run_installer_update,
 )
 
+if POETRY_VERSION < Version("1.3.0"):
+    # Poetry 1.2.x defined a different name for Cleo 1.x
+    from poetry.console.exceptions import (
+        PoetrySimpleConsoleException as PoetryConsoleError,
+    )
+else:
+    from poetry.console.exceptions import PoetryConsoleError
+
 
 def _pretty_group(group: str) -> str:
     return f" in group <c1>{group!r}</c1>"
@@ -299,4 +307,4 @@ class RelaxCommand(InitCommand, InstallerCommand):
                     for opt in sorted(invalid_options[group])
                 )
                 message_parts.append(f"{group} (via {opts})")
-            self.line(f"<error>Group(s) not found: {', '.join(message_parts)}</error>")
+            raise PoetryConsoleError(f"Group(s) not found: {', '.join(message_parts)}")

--- a/src/poetry_relax/command.py
+++ b/src/poetry_relax/command.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Any, List, cast
+from typing import Any, Dict, List, Set, cast
 
 # cleo is not PEP 561 compliant must be ignored
 # See https://github.com/python-poetry/cleo/pull/254
@@ -277,7 +277,7 @@ class RelaxCommand(InitCommand, InstallerCommand):
 
         return status
 
-    def _validate_group_options(self, group_options: dict[str, set[str]]) -> None:
+    def _validate_group_options(self, group_options: Dict[str, Set[str]]) -> None:
         """
         Raises en error if it detects that a group is not part of pyproject.toml
         """

--- a/src/poetry_relax/command.py
+++ b/src/poetry_relax/command.py
@@ -112,7 +112,7 @@ class RelaxCommand(InitCommand, InstallerCommand):
 
         # Validate given groups using Poetry's internal handler
         self._validate_group_options(
-            {opt: (self.option(opt) or []) for opt in {"only", "without", "group"}}
+            {opt: (self.option(opt) or set()) for opt in {"only", "without", "group"}}
         )
 
         groups = cast(List[str], self._get_only_group_option()) or list(

--- a/src/poetry_relax/command.py
+++ b/src/poetry_relax/command.py
@@ -34,7 +34,8 @@ class RelaxCommand(InitCommand, InstallerCommand):
             "group",
             "-G",
             description=(
-                "A group to relax constraints in. If not provided, all groups are used."
+                "A group to relax constraints in. If not provided, all groups are used"
+                "; including optional groups."
                 # If a group is specified, it is treated like the Poetry `--only` flag.
             ),
             flag=False,

--- a/tests/_utilities.py
+++ b/tests/_utilities.py
@@ -5,14 +5,25 @@ from functools import partial
 from pathlib import Path
 from typing import Any, Dict, Generator, Optional, Union
 
+import packaging.version
 import tomlkit
 from cleo.commands.command import Command
 from cleo.io.outputs.output import Verbosity
 from cleo.testers.command_tester import CommandTester as _CommandTester
 from poetry.console.application import Application as PoetryApplication
-from poetry.console.exceptions import PoetryConsoleError
 from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.utils.env import EnvManager
+
+from poetry_relax._core import POETRY_VERSION
+
+if POETRY_VERSION < packaging.version.Version("1.5.0"):
+    # Poetry 1.4.x and earlier defined a different name for Cleo 1.x
+    from poetry.console.exceptions import (
+        PoetrySimpleConsoleException as PoetryConsoleError,
+    )
+else:
+    from poetry.console.exceptions import PoetryConsoleError
+
 
 PYPROJECT = "pyproject.toml"
 LOCKFILE = "poetry.lock"

--- a/tests/_utilities.py
+++ b/tests/_utilities.py
@@ -3,7 +3,7 @@ import sys
 from contextlib import contextmanager
 from functools import partial
 from pathlib import Path
-from typing import Any, Dict, Generator, Union
+from typing import Any, Dict, Generator, Optional, Union
 
 import tomlkit
 from cleo.commands.command import Command
@@ -167,10 +167,10 @@ class PoetryCommandTester(_CommandTester):
     def execute(
         self,
         args: str = "",
-        inputs: str | None = None,
-        interactive: bool | None = None,
-        verbosity: Verbosity | None = None,
-        decorated: bool | None = None,
+        inputs: Optional[str] = None,
+        interactive: Optional[bool] = None,
+        verbosity: Optional[Verbosity] = None,
+        decorated: Optional[bool] = None,
         supports_utf8: bool = True,
     ) -> int:
         # Reload the application to ensure that project changes are reflected

--- a/tests/_utilities.py
+++ b/tests/_utilities.py
@@ -16,8 +16,8 @@ from poetry.utils.env import EnvManager
 
 from poetry_relax._core import POETRY_VERSION
 
-if POETRY_VERSION < packaging.version.Version("1.5.0"):
-    # Poetry 1.4.x and earlier defined a different name for Cleo 1.x
+if POETRY_VERSION < packaging.version.Version("1.3.0"):
+    # Poetry 1.2.x defined a different name for Cleo 1.x
     from poetry.console.exceptions import (
         PoetrySimpleConsoleException as PoetryConsoleError,
     )

--- a/tests/_utilities.py
+++ b/tests/_utilities.py
@@ -186,5 +186,5 @@ class PoetryCommandTester(_CommandTester):
             # Typically handling by poetry, but we need to handle it manually in our
             # testing
             self.io.write_line(str(exc))
-            self._status_code = exc.exit_code or 1
+            self._status_code = getattr(exc, "exit_code", None) or 1
             return self._status_code

--- a/tests/_utilities.py
+++ b/tests/_utilities.py
@@ -14,16 +14,7 @@ from poetry.console.application import Application as PoetryApplication
 from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.utils.env import EnvManager
 
-from poetry_relax._core import POETRY_VERSION
-
-if POETRY_VERSION < packaging.version.Version("1.3.0"):
-    # Poetry 1.2.x defined a different name for Cleo 1.x
-    from poetry.console.exceptions import (
-        PoetrySimpleConsoleException as PoetryConsoleError,
-    )
-else:
-    from poetry.console.exceptions import PoetryConsoleError
-
+from poetry_relax._core import PoetryConsoleError
 
 PYPROJECT = "pyproject.toml"
 LOCKFILE = "poetry.lock"

--- a/tests/_utilities.py
+++ b/tests/_utilities.py
@@ -6,11 +6,11 @@ from pathlib import Path
 from typing import Any, Dict, Generator, Union
 
 import tomlkit
-from poetry.console.exceptions import PoetryConsoleError
 from cleo.commands.command import Command
 from cleo.io.outputs.output import Verbosity
 from cleo.testers.command_tester import CommandTester as _CommandTester
 from poetry.console.application import Application as PoetryApplication
+from poetry.console.exceptions import PoetryConsoleError
 from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.utils.env import EnvManager
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,10 +1,12 @@
 import os
+import re
 import subprocess
 import sys
 import uuid
 from pathlib import Path
 from typing import Callable
 
+import poetry
 import pytest
 from cleo.io.outputs.output import Verbosity
 from cleo.testers.command_tester import CommandTester
@@ -91,7 +93,11 @@ def test_newly_initialized_project(relax_command: CommandTester, extra_options: 
 
 def test_group_does_not_exist(relax_command: CommandTester):
     with assert_pyproject_unchanged():
-        relax_command.execute("--group iamnotagroup")
+        with pytest.raises(
+            poetry.console.exceptions.GroupNotFound,
+            match=re.escape("Group(s) not found: iamnotagroup"),
+        ):
+            relax_command.execute("--group iamnotagroup")
 
     assert relax_command.status_code == 1
     assert_io_contains(

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -87,16 +87,10 @@ def test_newly_initialized_project(
 
 def test_group_does_not_exist(relax_command: PoetryCommandTester):
     with assert_pyproject_unchanged():
-        with pytest.raises(
-            poetry.console.exceptions.GroupNotFound,
-            match=re.escape("Group(s) not found: iamnotagroup"),
-        ):
-            relax_command.execute("--group iamnotagroup")
+        relax_command.execute("--group iamnotagroup")
 
     assert relax_command.status_code == 1
-    assert_io_contains(
-        "No dependencies found in group 'iamnotagroup'", relax_command.io
-    )
+    assert_io_contains("Group(s) not found: iamnotagroup", relax_command.io)
 
 
 def test_with_no_pyproject_toml(
@@ -387,7 +381,8 @@ def test_dry_run_flag_prevents_changes(
 
     if "--check" in extra_options:
         assert_io_contains(
-            "Checking dependencies for relaxable constraints", seeded_relax_command.io
+            "Checking dependencies in group 'main' for relaxable constraints",
+            seeded_relax_command.io,
         )
     assert_io_contains(
         "Skipped update of config file due to dry-run flag.", seeded_relax_command.io


### PR DESCRIPTION
Replaces #8 
Closes #7 

Unlike #8, this only runs the installer _once_ after editing the all of the groups and includes _all_ groups by default instead of excluding optional groups.

This also deprecates the `--group` option in favor of `--only` to match Poetry's options.